### PR TITLE
Fix typo in ContainerQueries.mdx

### DIFF
--- a/site/pages/docs/usage/container-queries.mdx
+++ b/site/pages/docs/usage/container-queries.mdx
@@ -8,7 +8,7 @@ import { CodeOutput } from '../../../components/CodeOutput';
 ## Container Queries
 
 [Container Queries](https://github.com/tailwindlabs/tailwindcss-container-queries) is a plugin for Tailwind v3.2+ that provides utilities for [container queries](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Container_Queries).
-Tailwind decided to use a new `@` suntax to differentiate it from media queries. In Typewind, just replace the `@` with `$` and you should be good to go!
+Tailwind decided to use a new `@` syntax to differentiate it from media queries. In Typewind, just replace the `@` with `$` and you should be good to go!
 
 ```jsx
 import { tw } from 'typewind';


### PR DESCRIPTION
In the docs it said "suntax" and I updated it to "syntax"